### PR TITLE
[Evals] Add OlympiadBenchMath (en)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Following, we show our evaluation results for the Sky-T1-32B-Preview model acros
 | LiveCodeBench-Medium | 56.8                    | 40.8   | 56.3  | 54.9       |
 | LiveCodeBench-Hard   | 17.9                    | 9.8   | 17.1  | 16.3       |
 | GPQA-Diamond         | 56.8                    | 45.5   | 52.5  | 75.2       |
-
+| OlympiadBench (Math, EN)    | 59.79	           | 46.74	| 62.17	 | -        | 
 
 
 ## Fully Open-source: Driving Progress Together

--- a/skythought/tools/eval.py
+++ b/skythought/tools/eval.py
@@ -14,6 +14,7 @@ eval_to_split = {
   "GSM8K": "test",
   "ARC-C": "test",
   "AMC23": "train",
+  "OlympiadBenchMath": "train",
 }
 
 def parse_arguments():

--- a/skythought/tools/inference_and_check.py
+++ b/skythought/tools/inference_and_check.py
@@ -101,7 +101,8 @@ def perform_inference_and_check(handler: TaskHandler, temperatures, max_tokens, 
                     results[problem_key]["token_usages"] = {}
                     prompt = conversations[idx][1]["content"]
                     results[problem_key]["prompt"] = prompt
-
+                    results[problem_key]["input_conversation"] = conversations[idx]
+                    
                 results[problem_key]["responses"][str(temp)] = response_entry
                 
                 if args.model.startswith("openai"):

--- a/skythought/tools/inference_and_check.py
+++ b/skythought/tools/inference_and_check.py
@@ -305,7 +305,7 @@ def perform_inference_and_save(handler: TaskHandler, temperatures, max_tokens, r
 
 def main():
     parser = argparse.ArgumentParser(description="Unified inference and checking for different datasets/tasks.")
-    parser.add_argument("--dataset", type=str, required=True, choices=["NUMINA", "APPS", "TACO", "MATH500", "AIME", "GPQADiamond", "MMLU", "MMLUPro", "LiveCodeBench", "GSM8K", "ARC-C", "AMC23"], help="Dataset to process.")
+    parser.add_argument("--dataset", type=str, required=True, choices=["NUMINA", "APPS", "TACO", "MATH500", "AIME", "GPQADiamond", "MMLU", "MMLUPro", "LiveCodeBench", "GSM8K", "ARC-C", "AMC23", "OlympiadBenchMath"], help="Dataset to process.")
     parser.add_argument("--model", type=str, required=True, default="Qwen/QwQ-32B-Preview", help="The model to run.")
     parser.add_argument("--tp", type=int, default=8, help="Tensor Parallelism Degree")
     parser.add_argument("--max_tokens", type=int, default=32768, help="Max tokens for the model.")

--- a/skythought/tools/util/task_handlers.py
+++ b/skythought/tools/util/task_handlers.py
@@ -77,14 +77,12 @@ class MathTaskHandler(TaskHandler):
             "reason": None,
         }
         curr_res = self.check_correctness(problem, generation=response)
-
         if curr_res:
             response_entry["correctness"] = True
             response_entry["reason"] = ""
         else:
             response_entry["correctness"] = False
             response_entry["reason"] = "Solution is incorrect."
-        
         return response_entry
     
     def make_conversations(self, data, system_prompt, model=None):

--- a/skythought/tools/util/task_handlers.py
+++ b/skythought/tools/util/task_handlers.py
@@ -14,6 +14,8 @@ from .math.testing_util import strip_answer_string, get_multiple_choice_answer, 
 from .livecodebench.testing_util import unsafe_lcb_runTests, map_to_example, has_test_type, post_process_code, translate_private_test_cases
 from .common import TimeoutException, timeout
 from util.model_utils import *
+import logging
+logging.basicConfig(level=logging.INFO)
 
 def has_code(response):
     pattern = r"```(?:[a-zA-Z]*)\n(.*?)```"
@@ -51,6 +53,10 @@ class TaskHandler:
     
 class MathTaskHandler(TaskHandler):
     @staticmethod
+    def get_question_key():
+        return "problem"
+
+    @staticmethod
     def generate_prompt(prompt):
         return "Return your final response within \\boxed{{}}. " + prompt
     
@@ -71,19 +77,20 @@ class MathTaskHandler(TaskHandler):
             "reason": None,
         }
         curr_res = self.check_correctness(problem, generation=response)
+
         if curr_res:
             response_entry["correctness"] = True
             response_entry["reason"] = ""
         else:
             response_entry["correctness"] = False
             response_entry["reason"] = "Solution is incorrect."
-    
+        
         return response_entry
     
     def make_conversations(self, data, system_prompt, model=None):
         conversations = []
         for problem in data:
-            prompt_text = self.generate_prompt(problem["problem"])
+            prompt_text = self.generate_prompt(problem[self.get_question_key()])
             conversations.append([
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": prompt_text}
@@ -91,7 +98,7 @@ class MathTaskHandler(TaskHandler):
         return conversations
     
     def process_remaining_data(self, train_data, results):
-        return [row.to_dict() for _, row in train_data.iterrows() if str(row["problem"]) not in results]
+        return [row.to_dict() for _, row in train_data.iterrows() if str(row[self.get_question_key()]) not in results]
 
     def load_and_filter_dataset(self, start, end, split="test", source=None, filter_difficulty=False, args=None):
         dataset = load_dataset(self.dataset)
@@ -855,6 +862,27 @@ class AMC23TaskHandler(MathTaskHandler):
         return filtered_data.iloc[start:end] if end > 0 else filtered_data.iloc[start:]
 
 
+class OlympiadBenchMathTaskHandler(MathTaskHandler): 
+    def __init__(self):
+        self.dataset = "Hothan/OlympiadBench"
+        self.source = "OE_TO_maths_en_COMP"
+
+    @staticmethod
+    def get_question_key():
+        return "question"
+    
+    def load_and_filter_dataset(self, start, end, split="train", source=None, filter_difficulty=False, args=None):
+        dataset = load_dataset(self.dataset, self.source)
+        train_data = dataset[split].to_pandas()
+        return train_data.iloc[start:end] if end > 0 else train_data.iloc[start:]
+    
+    def check_correctness(self, problem, generation):
+        # all problems have final answer in a list 
+        answer = strip_answer_string(problem["final_answer"][0])
+        pred = extract_answer(generation)
+        pred = strip_answer_string(pred)
+        return math_equal(pred, answer)
+
 TASK_HANDLERS = {
     "NUMINA": NUMINATaskHandler,
     "APPS": APPSTaskHandler,
@@ -868,4 +896,5 @@ TASK_HANDLERS = {
     "GSM8K": GSM8KTaskHandler,
     "ARC-C": ARCChallengeTaskHandler,
     "AMC23": AMC23TaskHandler,
+    "OlympiadBenchMath": OlympiadBenchMathTaskHandler,
 }


### PR DESCRIPTION
# What does this PR do? 

Adds support for OlympiadBenchMath (en).  

Current results: 

| Metric | Sky-T1-32B-Preview | Qwen-2.5-32B-Instruct | QwQ-32B-Preview | Qwen2.5-Math-7B-Instruct
|---------|-------------------|---------------------|-----------------|-----------|
OlympiadBenchMath (en) | 59.79 |  46.74 | 62.17 |   40.5 | 


`Qwen2.5-Math-7B-Instruct` result from the [paper](https://arxiv.org/pdf/2409.12122v1): 41.6 . I'm guessing the slight discrepancy is due to different user instruction template ( in `generate_prompt`) . 

TODO: 
- [x] Verify string parsing (currently uses the same parsing as MATH following https://github.com/QwenLM/Qwen2.5-Math/tree/main/evaluation   


LMK if you want to put the results in the README cc @lynnliu030 @caoshiyi 