### PR TITLE
[Evals] Use a lower writer batch size for livecodebench 

### DIFF
--- a/skythought/tools/util/task_handlers.py
+++ b/skythought/tools/util/task_handlers.py
@@ -648,7 +648,7 @@ class LiveCodeBenchTaskHandler(TaskHandler):
         dataset = load_dataset("livecodebench/code_generation_lite", version_tag="release_v2", split=split, trust_remote_code=True)
         if filter_difficulty:
             dataset = dataset.filter(lambda example: example['difficulty'] == source)
-        # We use a lower writer_batch_size to avoid pandas issues. JSON entries with LiveCodeBench are large. 
+        # We use a lower writer_batch_size to avoid pyarrow issues. JSON entries with LiveCodeBench are large. 
         # See: https://github.com/NovaSky-AI/SkyThought/pull/45 for details. 
         dataset = dataset.map(
             lambda example: {

--- a/skythought/tools/util/task_handlers.py
+++ b/skythought/tools/util/task_handlers.py
@@ -648,6 +648,8 @@ class LiveCodeBenchTaskHandler(TaskHandler):
         dataset = load_dataset("livecodebench/code_generation_lite", version_tag="release_v2", split=split, trust_remote_code=True)
         if filter_difficulty:
             dataset = dataset.filter(lambda example: example['difficulty'] == source)
+        # We use a lower writer_batch_size to avoid pandas issues. JSON entries with LiveCodeBench are large. 
+        # See: https://github.com/NovaSky-AI/SkyThought/pull/45 for details. 
         dataset = dataset.map(
             lambda example: {
                 "private_test_cases": translate_private_test_cases(example["private_test_cases"])

--- a/skythought/tools/util/task_handlers.py
+++ b/skythought/tools/util/task_handlers.py
@@ -651,10 +651,10 @@ class LiveCodeBenchTaskHandler(TaskHandler):
         dataset = dataset.map(
             lambda example: {
                 "private_test_cases": translate_private_test_cases(example["private_test_cases"])
-            }
+            }, writer_batch_size=100
         )
         # Apply the mapping function
-        dataset = dataset.map(map_to_example, remove_columns=dataset.column_names).to_pandas()
+        dataset = dataset.map(map_to_example, remove_columns=dataset.column_names, writer_batch_size=100).to_pandas()
         return dataset.iloc[start:end] if end > 0 else dataset.iloc[start:]
 
     def process_remaining_data(self, train_data, results):


### PR DESCRIPTION
# What does this PR do?

Fixes an issue with LiveCodeBench  evaluation. Currently if you run:

```
python inference_and_check.py --dataset LiveCodeBench   --model Qwen/Qwen2.5-1.5B-Instruct  --tp 4 --max_tokens 16384 --split test --source all --result-dir data 
```

you'll get an error in the preprocessing stage: 

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/mnt/sumanth/skythought/skythought/tools/inference_and_check.py", line 364, in <module>
[rank0]:     main()
[rank0]:   File "/mnt/sumanth/skythought/skythought/tools/inference_and_check.py", line 361, in main
[rank0]:     perform_inference_and_check(handler, temperatures, max_tokens, result_file, llm, system_prompt, args)
[rank0]:   File "/mnt/sumanth/skythought/skythought/tools/inference_and_check.py", line 47, in perform_inference_and_check
[rank0]:     train_data = handler.load_and_filter_dataset(args.start, args.end, split=args.split, source=args.source, \
[rank0]:   File "/mnt/sumanth/skythought/skythought/tools/util/task_handlers.py", line 651, in load_and_filter_dataset
[rank0]:     dataset = dataset.map(
[rank0]:   File "/mnt/sumanth/skythought/.venv/lib/python3.10/site-packages/datasets/arrow_dataset.py", line 560, in wrapper
[rank0]:     out: Union["Dataset", "DatasetDict"] = func(self, *args, **kwargs)
[rank0]:   File "/mnt/sumanth/skythought/.venv/lib/python3.10/site-packages/datasets/arrow_dataset.py", line 3073, in map
[rank0]:     for rank, done, content in Dataset._map_single(**dataset_kwargs):
[rank0]:   File "/mnt/sumanth/skythought/.venv/lib/python3.10/site-packages/datasets/arrow_dataset.py", line 3511, in _map_single
[rank0]:     writer.finalize()
[rank0]:   File "/mnt/sumanth/skythought/.venv/lib/python3.10/site-packages/datasets/arrow_writer.py", line 636, in finalize
[rank0]:     self.write_examples_on_file()
[rank0]:   File "/mnt/sumanth/skythought/.venv/lib/python3.10/site-packages/datasets/arrow_writer.py", line 495, in write_examples_on_file
[rank0]:     self.write_batch(batch_examples=batch_examples)
[rank0]:   File "/mnt/sumanth/skythought/.venv/lib/python3.10/site-packages/datasets/arrow_writer.py", line 609, in write_batch
[rank0]:     self.write_table(pa_table, writer_batch_size)
[rank0]:   File "/mnt/sumanth/skythought/.venv/lib/python3.10/site-packages/datasets/arrow_writer.py", line 621, in write_table
[rank0]:     pa_table = pa_table.combine_chunks()
[rank0]:   File "pyarrow/table.pxi", line 4512, in pyarrow.lib.Table.combine_chunks
[rank0]:   File "pyarrow/error.pxi", line 155, in pyarrow.lib.pyarrow_internal_check_status
[rank0]:   File "pyarrow/error.pxi", line 92, in pyarrow.lib.check_status
[rank0]: pyarrow.lib.ArrowInvalid: offset overflow while concatenating arrays
``` 

The fix is to use a lower `writer_batch_size` during `dataset.map` operation since the JSON entries are large.  Related issue: https://github.com/huggingface/datasets/issues/6206#issuecomment-2061629230  

