### PR TITLE
[Evals] Add support for OMNI Math

### DIFF
--- a/skythought/evals/tasks/__init__.py
+++ b/skythought/evals/tasks/__init__.py
@@ -13,6 +13,7 @@ from .minervamath.minervamath_handler import MinervaMathTaskHandler
 from .mmlu.mmlu_handler import MMLUProTaskHandler, MMLUTaskHandler
 from .numina.numina_handler import NUMINATaskHandler
 from .olympiadbench.olympiadbench_handler import OlympiadBenchMathTaskHandler
+from .omni_math.omni_handler import OMNIMathTaskHandler
 from .taco.taco_handler import TACOTaskHandler
 from .task_util import get_tasks
 
@@ -31,6 +32,7 @@ TASK_HANDLER_MAP = {
     "amc23": AMC23TaskHandler,
     "minervamath": MinervaMathTaskHandler,
     "olympiadbench_math": OlympiadBenchMathTaskHandler,
+    "omni_math": OMNIMathTaskHandler,
 }
 TASK_NAMES_TO_YAML = get_tasks(os.path.dirname(__file__))
 

--- a/skythought/evals/tasks/omni_math/omni_handler.py
+++ b/skythought/evals/tasks/omni_math/omni_handler.py
@@ -12,8 +12,7 @@ class OMNIMathTaskHandler(MathTaskHandler):
         return self.task_config.templating_parameters["template"].format(**problem)
 
     def check_correctness(self, problem, generation):
-        # no preprocessing needed for answer key
-        answer = problem[self.task_config.answer_key]
+        answer = extract_answer(problem[self.task_config.answer_key])
         pred = extract_answer(generation)
         pred = strip_answer_string(pred)
         return math_equal(pred, answer)

--- a/skythought/evals/tasks/omni_math/omni_handler.py
+++ b/skythought/evals/tasks/omni_math/omni_handler.py
@@ -1,0 +1,19 @@
+from skythought.evals.util.math_parsing_util import (
+    extract_answer,
+    math_equal,
+    strip_answer_string,
+)
+
+from ..math.math_handler import MathTaskHandler
+
+
+class OMNIMathTaskHandler(MathTaskHandler):
+    def generate_prompt(self, problem):
+        return self.task_config.templating_parameters["template"].format(**problem)
+
+    def check_correctness(self, problem, generation):
+        # no preprocessing needed for answer key
+        answer = problem[self.task_config.answer_key]
+        pred = extract_answer(generation)
+        pred = strip_answer_string(pred)
+        return math_equal(pred, answer)

--- a/skythought/evals/tasks/omni_math/omni_handler.py
+++ b/skythought/evals/tasks/omni_math/omni_handler.py
@@ -12,7 +12,8 @@ class OMNIMathTaskHandler(MathTaskHandler):
         return self.task_config.templating_parameters["template"].format(**problem)
 
     def check_correctness(self, problem, generation):
-        answer = extract_answer(problem[self.task_config.answer_key])
+        # no preprocessing needed
+        answer = problem[self.task_config.answer_key]
         pred = extract_answer(generation)
         pred = strip_answer_string(pred)
         return math_equal(pred, answer)

--- a/skythought/evals/tasks/omni_math/omni_math.yaml
+++ b/skythought/evals/tasks/omni_math/omni_math.yaml
@@ -6,7 +6,6 @@ dataset_kwargs:
   # NOTE: This is using the subset for rule-based evaluation in the below PR
   revision: refs/pr/2 
 question_key: problem
-answer_key: answer
-dataset_split: test
+answer_key: solution
 templating_parameters: 
   template: "Return your final response within \\boxed{{}}. {problem}"

--- a/skythought/evals/tasks/omni_math/omni_math.yaml
+++ b/skythought/evals/tasks/omni_math/omni_math.yaml
@@ -6,6 +6,6 @@ dataset_kwargs:
   # NOTE: This is using the subset for rule-based evaluation in the below PR
   revision: refs/pr/2 
 question_key: problem
-answer_key: solution
+answer_key: answer
 templating_parameters: 
   template: "Return your final response within \\boxed{{}}. {problem}"

--- a/skythought/evals/tasks/omni_math/omni_math.yaml
+++ b/skythought/evals/tasks/omni_math/omni_math.yaml
@@ -1,0 +1,12 @@
+handler: math
+dataset_path: "KbsdJames/Omni-MATH"  # repo ID in huggingface
+dataset_subset: null # which subset on huggingface
+dataset_split: test_rule_based # Rule based evaluation
+dataset_kwargs:
+  # NOTE: This is using the subset for rule-based evaluation in the below PR
+  revision: refs/pr/2 
+question_key: problem
+answer_key: answer
+dataset_split: test
+templating_parameters: 
+  template: "Return your final response within \\boxed{{}}. {problem}"


### PR DESCRIPTION
# What does this PR do? 


Adds OMNI-Math. Part 1 of resolving #51 . 


FOr OMNI-Math, the authors did LLM as a Judge evaluation with GPT-4o, but also provided a benchmark subset for rule-based evlauation. We do not support LLM as a Judge yet, so this PR only adds support for rule-based evaluation. 


The dataset for rule-based evaluation is provided in this repo: https://github.com/KbsdJames/omni-math-rule 

I have uploaded the same as an alternate split in the official HF dataset: https://huggingface.co/datasets/KbsdJames/Omni-MATH/discussions/2 