### PR TITLE
Suppress pydantic warning for protected namespace

### DIFF
--- a/skythought/evals/models/base.py
+++ b/skythought/evals/models/base.py
@@ -3,8 +3,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import yaml
-from pydantic import BaseModel, Field, PrivateAttr, model_validator, ConfigDict
-
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 MODEL_CONFIG_FILE_PATH = Path(__file__).parent / "model_configs.yaml"
 # cache the configs in a global var
@@ -36,7 +35,7 @@ def read_yaml(path: str):
 
 
 class ModelConfig(BaseModel):
-    model_config =  ConfigDict(protected_namespaces=())
+    model_config = ConfigDict(protected_namespaces=())
 
     model_id: str
     name: Optional[str] = Field(default=None)

--- a/skythought/evals/models/base.py
+++ b/skythought/evals/models/base.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from typing import Optional, Union
 
 import yaml
-from pydantic import BaseModel, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, model_validator, ConfigDict
+
 
 MODEL_CONFIG_FILE_PATH = Path(__file__).parent / "model_configs.yaml"
 # cache the configs in a global var
@@ -35,6 +36,8 @@ def read_yaml(path: str):
 
 
 class ModelConfig(BaseModel):
+    model_config =  ConfigDict(protected_namespaces=())
+
     model_id: str
     name: Optional[str] = Field(default=None)
     # can be a string or a path to a file with the string


### PR DESCRIPTION
# What does this PR do?

Tiny PR to suppress a pydantic warning at import time:

```
/home/ray/anaconda3/lib/python3.9/site-packages/pydantic/_internal/_fields.py:132: UserWarning: Field "model_id" in ModelConfig has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
```