### PR TITLE
[Evals] Replace 'getargspec` with `getfullargspec` to support python 3.12

### DIFF
--- a/skythought/evals/scoring/utils/pyext2.py
+++ b/skythought/evals/scoring/utils/pyext2.py
@@ -108,18 +108,18 @@ else:
         newf.__dict__.update(f.__dict__)
         return newf
     def argspec(f):
-        return inspect.getargspec(f)
+        return inspect.getfullargspec(f)
     eval(compile('def _exec(m,g): exec m in g', '<exec>', 'exec'))
 
 def _gettypes(args):
     return tuple(map(type, args))
 
-oargspec = inspect.getargspec
+oargspec = inspect.getfullargspec
 
 def _argspec(func):
     return __targspec(func, oargspec)
 
-inspect.getargspec = _argspec
+inspect.getfullargspec = _argspec
 
 try:
     import IPython
@@ -127,10 +127,10 @@ except ImportError:
     IPython = None
 else:
     # Replace IPython's argspec
-    oipyargspec = IPython.core.oinspect.getargspec
+    oipyargspec = IPython.core.oinspect.getfullargspec
     def _ipyargspec(func):
         return __targspec(func, oipyargspec, '__orig_arg_ipy__')
-    IPython.core.oinspect.getargspec = _ipyargspec
+    IPython.core.oinspect.getfullargspec = _ipyargspec
 
 class overload(object):
     '''Simple function overloading in Python.'''
@@ -177,7 +177,7 @@ class overload(object):
             _newf.__is_overload__ = True
             _newf.__orig_arg__ = argspec(f)
             if IPython:
-                _newf.__orig_arg_ipy__ = IPython.core.oinspect.getargspec(f)
+                _newf.__orig_arg_ipy__ = IPython.core.oinspect.getfullargspec(f)
             return _newf
         return _wrap
     @classmethod
@@ -232,7 +232,7 @@ class overload(object):
             _newf.__is_overload__ = True
             _newf.__orig_arg__ = argspec(f)
             if IPython:
-                _newf.__orig_arg_ipy__ = IPython.core.oinspect.getargspec(f)
+                _newf.__orig_arg_ipy__ = IPython.core.oinspect.getfullargspec(f)
             return _newf
         return _wrap
 

--- a/skythought/evals/tasks/taco/pyext2.py
+++ b/skythought/evals/tasks/taco/pyext2.py
@@ -108,18 +108,18 @@ else:
         newf.__dict__.update(f.__dict__)
         return newf
     def argspec(f):
-        return inspect.getargspec(f)
+        return inspect.getfullargspec(f)
     eval(compile('def _exec(m,g): exec m in g', '<exec>', 'exec'))
 
 def _gettypes(args):
     return tuple(map(type, args))
 
-oargspec = inspect.getargspec
+oargspec = inspect.getfullargspec
 
 def _argspec(func):
     return __targspec(func, oargspec)
 
-inspect.getargspec = _argspec
+inspect.getfullargspec = _argspec
 
 try:
     import IPython
@@ -127,10 +127,10 @@ except ImportError:
     IPython = None
 else:
     # Replace IPython's argspec
-    oipyargspec = IPython.core.oinspect.getargspec
+    oipyargspec = IPython.core.oinspect.getfullargspec
     def _ipyargspec(func):
         return __targspec(func, oipyargspec, '__orig_arg_ipy__')
-    IPython.core.oinspect.getargspec = _ipyargspec
+    IPython.core.oinspect.getfullargspec = _ipyargspec
 
 class overload(object):
     '''Simple function overloading in Python.'''
@@ -177,7 +177,7 @@ class overload(object):
             _newf.__is_overload__ = True
             _newf.__orig_arg__ = argspec(f)
             if IPython:
-                _newf.__orig_arg_ipy__ = IPython.core.oinspect.getargspec(f)
+                _newf.__orig_arg_ipy__ = IPython.core.oinspect.getfullargspec(f)
             return _newf
         return _wrap
     @classmethod
@@ -232,7 +232,7 @@ class overload(object):
             _newf.__is_overload__ = True
             _newf.__orig_arg__ = argspec(f)
             if IPython:
-                _newf.__orig_arg_ipy__ = IPython.core.oinspect.getargspec(f)
+                _newf.__orig_arg_ipy__ = IPython.core.oinspect.getfullargspec(f)
             return _newf
         return _wrap
 


### PR DESCRIPTION
# What does this PR do?


Adds compatibility for python 3.12. 


TODO:
- [ ] Verify backwards compatibility with python 3.10 