### PR TITLE
[Evals] Fix issue with reading from system prompt in file

### DIFF
--- a/scripts/response_rewrite.py
+++ b/scripts/response_rewrite.py
@@ -507,7 +507,7 @@ def main():
         variants_dataset, ["fcs", "fcs_plus1", "fcs_reflection"], llm
     )
 
-    system_prompt = ModelConfig.from_model_id(args.target_model).system_prompt
+    system_prompt = str(ModelConfig.from_model_id(args.target_model).system_prompt)
 
     # Generate conversation format for each variant, which can be used in SimPO/DPO/etc.
     fcs_convo = make_preference_conversations(final_dataset, "fcs", system_prompt)

--- a/skythought/evals/inference_and_check.py
+++ b/skythought/evals/inference_and_check.py
@@ -237,7 +237,7 @@ def generate_responses_for_dataset(
     # Prepare conversations
     conversations = handler.make_conversations(
         remaining_data,
-        model_config.system_prompt,
+        str(model_config.system_prompt),
         model_config.user_template,
         model_config.assistant_prefill,
     )

--- a/skythought/evals/models/base.py
+++ b/skythought/evals/models/base.py
@@ -27,7 +27,7 @@ class StringInFile(BaseModel):
     @property
     def string(self):
         return self._string
-    
+
     def __str__(self) -> str:
         return self._string
 
@@ -52,7 +52,7 @@ class ModelConfig(BaseModel):
         if self.name is None:
             self.name = self.model_id.split("/")[-1]
         return self
-    
+
     @classmethod
     def from_model_id(
         cls,

--- a/skythought/evals/models/base.py
+++ b/skythought/evals/models/base.py
@@ -27,6 +27,9 @@ class StringInFile(BaseModel):
     @property
     def string(self):
         return self._string
+    
+    def __str__(self) -> str:
+        return self._string
 
 
 def read_yaml(path: str):
@@ -49,7 +52,7 @@ class ModelConfig(BaseModel):
         if self.name is None:
             self.name = self.model_id.split("/")[-1]
         return self
-
+    
     @classmethod
     def from_model_id(
         cls,


### PR DESCRIPTION
# What does this PR do?

Fixes an issue when reading from system prompt in file:

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/ray/anaconda3/bin/skythought", line 10, in <module>
[rank0]:     sys.exit(main())
[rank0]:              ^^^^^^
[rank0]:   File "/home/ray/default/SkyThought/skythought/evals/cli.py", line 586, in main
[rank0]:     app()
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/typer/main.py", line 339, in __call__
[rank0]:     raise e
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/typer/main.py", line 322, in __call__
[rank0]:     return get_command(self)(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
[rank0]:     return self.main(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/typer/core.py", line 740, in main
[rank0]:     return _main(
[rank0]:            ^^^^^^
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/typer/core.py", line 195, in _main
[rank0]:     rv = self.invoke(ctx)
[rank0]:          ^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
[rank0]:     return _process_result(sub_ctx.command.invoke(sub_ctx))
[rank0]:                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
[rank0]:     return ctx.invoke(self.callback, **ctx.params)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/click/core.py", line 783, in invoke
[rank0]:     return __callback(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/typer/main.py", line 697, in wrapper
[rank0]:     return callback(**use_params)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ray/default/SkyThought/skythought/evals/cli.py", line 332, in evaluate
[rank0]:     generate_and_score(
[rank0]:   File "/home/ray/default/SkyThought/skythought/evals/inference_and_check.py", line 409, in generate_and_score
[rank0]:     id_to_results, prompt_tokens, completion_tokens = generate_responses_for_dataset(
[rank0]:                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ray/default/SkyThought/skythought/evals/inference_and_check.py", line 250, in generate_responses_for_dataset
[rank0]:     responses = inference(
[rank0]:                 ^^^^^^^^^^
[rank0]:   File "/home/ray/default/SkyThought/skythought/evals/inference_and_check.py", line 193, in inference
[rank0]:     llm.chat(
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/vllm/entrypoints/llm.py", line 702, in chat
[rank0]:     conversation, mm_data = parse_chat_messages(
[rank0]:                             ^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/vllm/entrypoints/chat_utils.py", line 1030, in parse_chat_messages
[rank0]:     sub_messages = _parse_chat_message_content(
[rank0]:                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/vllm/entrypoints/chat_utils.py", line 981, in _parse_chat_message_content
[rank0]:     result = _parse_chat_message_content_parts(
[rank0]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/vllm/entrypoints/chat_utils.py", line 881, in _parse_chat_message_content_parts
[rank0]:     parse_res = _parse_chat_message_content_part(
[rank0]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/vllm/entrypoints/chat_utils.py", line 919, in _parse_chat_message_content_part
[rank0]:     part_type, content = _parse_chat_message_content_mm_part(part)
[rank0]:                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ray/anaconda3/lib/python3.12/site-packages/vllm/entrypoints/chat_utils.py", line 823, in _parse_chat_message_content_mm_part
[rank0]:     assert isinstance(
[rank0]:            ^^^^^^^^^^^
[rank0]: AssertionError
```

The error itself is hard to read but the root cause is that `model_config.system_prompt` can be a string or a StringInFile object...Before passing it to the task handler, we need to read the string from the file/ get the underlying `_string` atttribute from `StringInFile` . 