### PR TITLE
[Evals] Fix MinervaMath dataset YAML for correct evaluation

### DIFF
--- a/skythought/evals/tasks/minervamath/minervamath.yaml
+++ b/skythought/evals/tasks/minervamath/minervamath.yaml
@@ -1,8 +1,8 @@
 handler: math
-dataset_path: "svc-huggingface/minerva-math" # repo ID in huggingface
+dataset_path: "math-ai/minervamath" # repo ID in huggingface
 dataset_subset: null # which subset on huggingface
-question_key: problem
-answer_key: solution
+question_key: question
+answer_key: answer
 dataset_split: test
 templating_parameters: 
-  template: "Return your final response within \\boxed{{}}. {problem}"
+  template: "Return your final response within \\boxed{{}}. {question}"


### PR DESCRIPTION
In the MinervaMath dataset [svc-huggingface/minerva-math](https://huggingface.co/datasets/svc-huggingface/minerva-math), the solution field contains both the problem-solving process and the final answer. For example:
> Start with:
\[
s=\alpha f \text {, }
\]
where $s$ is the diameter of the image, $f$ the focal length, and $\alpha$ the angular diameter of the planet. For the values given in the problem:
\[
s=\frac{45}{3600} \frac{\pi}{180} 7200=\boxed{1.6} \mathrm{~cm}
\]

**This format leads to an evaluation accuracy of 0**, as the answer is embedded within the full solution text. Since svc-huggingface/minerva-math does not provide a separate field for the final answer, I switched to using the [math-ai/minervamath](https://huggingface.co/datasets/math-ai/minervamath) dataset, which includes a clearly separated answer field. I also updated the YAML configuration for the MinervaMath dataset accordingly.

After this modification, the accuracy of Qwen/Qwen2.5-Math-7B on MinervaMath improved **from 0 to 0.2684**, indicating that the bug has been resolved.