### PR TITLE
[evals] Update pyproject.toml, forcing datasets<4.0.0 to avoid errors in benchmarks that requires "dataset scripts" features.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "vllm==0.7.0",
     "word2number",
     "scipy",
-    "datasets",
+    "datasets<4.0.0",
     "latex2sympy2",
     "pydantic",
     "setuptools",


### PR DESCRIPTION
`datasets` package is officially updated to 4.0.0 on 2025.07.10.  

The **dataset scripts**, which are used in some benchmarks (e.g., LiveCodeBench), are no longer supported.  

So `datasets` version is forced "<4.0.0" in the new commit.